### PR TITLE
Start list item number from the one, not zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ class Markdown extends Component {
 
         if (ordered) {
             return(
-                <Text style={styles.listItemNumber}>{index + '.'}</Text>
+                <Text style={styles.listItemNumber}>{index + 1 + '.'}</Text>
             );
         }
 


### PR DESCRIPTION
I think most people prefer to see '1' as the first number of ordered list.