### PR TITLE
Don't wrap text unexpectedly for block items

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ class Markdown extends Component {
         else {
             return (
                 <View key={'block_' + key} style={styles.block}>
-                    {nodes}
+                    <Text>{nodes}</Text>
                 </View>
             );
         }


### PR DESCRIPTION
This sets the wrapper element to `display: block` which renders items correctly on the same line.  Please see #18 for discussion.
